### PR TITLE
fix syntax error

### DIFF
--- a/toolbox_pincat/ir_mri_sensemap_sim.m
+++ b/toolbox_pincat/ir_mri_sensemap_sim.m
@@ -477,5 +477,5 @@ case 'test'
 	prompt
 	ir_mri_sensemap_sim_test3
 otherwise
-	fail('bad argument "%s"', varargin{1})
+	fail('bad argument "%s"', arg)
 end


### PR DESCRIPTION
Same as https://github.com/JeffFessler/mirt/pull/2:
"I'm using Matlab R2019b, and in that version, the line I changed throws an error (and it looks like a typo caused by copy-paste)."